### PR TITLE
Jump to predicate when searching for it

### DIFF
--- a/page.html
+++ b/page.html
@@ -26,7 +26,7 @@
 	
 	  <div class="predicates">
 	    {% for predicate in predicates %}
-	    <div class="predicate">
+        <div class="predicate" id="{{ predicate.predicate }}">
 	      <h4>{{ predicate.name }}</h4>
 	      <div>{{ predicate.description }}</div>
 	    </div>


### PR DESCRIPTION
When searching for a predicate, the fact that it only jumped into the library page and not into the predicate description itself was annoying me. I think this is a good feature to have in a documentation site.

This also makes so that operators like `(=)/2` are displayed with parenthesis (in a way that makes them a valid term) in the search suggestions.