### PR TITLE
flake.nix

### DIFF
--- a/doclog.sh
+++ b/doclog.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
-scryer-prolog -g 'run("'$1'", "'$2'").' main.pl
+DOCLOG=$(realpath $(dirname $0))
+SOURCE=$(realpath $1)
+OUTPUT=$(realpath $2)
+
+cd $DOCLOG
+scryer-prolog -g 'run("'$SOURCE'", "'$OUTPUT'").' main.pl
+cd -

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1729850857,
+        "narHash": "sha256-WvLXzNNnnw+qpFOmgaM3JUlNEH+T4s22b5i2oyyCpXE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "41dea55321e5a999b17033296ac05fe8a8b5a257",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,63 @@
+{
+  description = "DocLog builds documentation from source code in Prolog";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem(system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      with pkgs; rec {
+        packages = rec {
+          default = doclog;
+
+          teruel.src = fetchFromGitHub {
+            owner = "aarroyoc";
+            repo = "teruel";
+            rev = "v1.0.1";
+            hash = "sha256-Wi8Z3H53xsegMByW69IskLxJhMmLkRVcLnQAPdFmL5Q=";
+          };
+
+          djota.src = fetchFromGitHub {
+            owner = "aarroyoc";
+            repo = "djota";
+            rev = "v0.1.3";
+            hash = "sha256-GX4R+eI2AfgnVwh2iNR9Hs5UGoG9pKLnD0bybqb8MQk=";
+          };
+
+          doclog = stdenv.mkDerivation {
+            pname = "doclog";
+            version = "0.0.1";
+            src = ./.;
+            dontBuild = true;
+
+            installPhase = ''
+              mkdir -p $out; cd $out
+              cp -r ${teruel.src} $out/teruel
+              cp -r ${djota.src} $out/djota
+              cp -r ${scryer-prolog.src} $out/scryer-prolog
+              cp $src/* $out
+              sed -i 's@scryer-prolog@${scryer-prolog}/bin/scryer-prolog@' doclog.sh
+              chmod +x doclog.sh
+              ln doclog.sh doclog
+            '';
+
+            homepage = "https://github.com/aarroyoc/doclog";
+            license = lib.licenses.bsd3.fullName;
+          };
+        };
+
+        apps = {
+          doclog = {
+            type = "app";
+            program = "${packages.doclog}/doclog";
+          };
+        };
+        defaultApp = apps.doclog;
+      }
+    );
+}


### PR DESCRIPTION
Hey Adrián,
it's a pleasure to read so nice prolog code, I very enjoyed it :)

Searching in your repositories, it seems like you know the [NIX buildsystem](https://nixos.org/) and I don't need expain or convince you about having a flake.nix. If you have any questions anyway, let me know…

To make it work, I changed `doclog.sh` to support running DocLog from others than the current directory. I implemented it by getting the paths of the arguments using `realpath` and `dirname` from coreutils (should be available on nearly every linux) and than changing into the directory of the called executable.
An alternative approach would be modifying `main.pl`.

You can test the flake when you are in a repository with DocLog documentation (or change the first argument):
```sh
nix run github:johannesloetzsch/doclog# . www
```

If you want, I could package DocLog for the [official nixpkgs](https://github.com/NixOS/nixpkgs)?