### PR TITLE
Regenerate only changed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,5 @@ While developing, it might be usefull to rebuild everytime something in the SOUR
 ```
 ./watch.sh SOURCE_FOLDER OUTPUT_FOLDER
 ```
+
+There's support for incremental compilation, however, this incremental compilation won't update the sidebars.


### PR DESCRIPTION
Implements #6 

Adds incremental compilation for the content of the files, but it doesn't update the sidebars and the footer. To regenerate those, a clean build is needed.